### PR TITLE
Fix some small Issues

### DIFF
--- a/spack/var/spack/repos/amd/packages/blis/package.py
+++ b/spack/var/spack/repos/amd/packages/blis/package.py
@@ -35,13 +35,13 @@ class Blis(Package):
     phases = ['configure', 'build', 'install']
 
     def configure(self, spec, prefix):
-	config_args = []
+        config_args = []
 
-	config_args.append("--enable-threading=" +
+        config_args.append("--enable-threading=" +
                            spec.variants['threads'].value)
 
-	config_args.append("--enable-cblas")
-	config_args.append("auto")
+        config_args.append("--enable-cblas")
+        config_args.append("auto")
         configure("--prefix=" + prefix,
                   *config_args)
 

--- a/spack/var/spack/repos/amd/packages/fftw/package.py
+++ b/spack/var/spack/repos/amd/packages/fftw/package.py
@@ -38,15 +38,15 @@ class Fftw(AutotoolsPackage):
 
     conflicts('%gcc@7:7.2', when="@2.1")
     def configure(self, spec, prefix):
-	config_args = []
+        config_args = []
         config_args = [
-	    '--enable-sse2',
-	    '--enable-avx',
-	    '--enable-avx2',
-	    '--enable-mpi',
-	    '--enable-openmp',
-	    '--enable-shared',
-	    '--enable-amd-opt'
+            '--enable-sse2',
+            '--enable-avx',
+            '--enable-avx2',
+            '--enable-mpi',
+            '--enable-openmp',
+            '--enable-shared',
+            '--enable-amd-opt'
         ]
 
         if '+single' in self.spec:

--- a/spack/var/spack/repos/amd/packages/fftw/package.py
+++ b/spack/var/spack/repos/amd/packages/fftw/package.py
@@ -26,7 +26,7 @@ class Fftw(AutotoolsPackage):
     version('2.1', tag='2.1')
     version('2.0', tag='2.0')
 
-    variant('single', description='single precision')
+    variant('single', default=False, description='single precision')
 
     depends_on('mpi')
     depends_on('automake')


### PR DESCRIPTION
Python 3 requires very clean indentation rules. So reformat stuff a little.
Variants in spack need a default.